### PR TITLE
fix: Static adapter settings

### DIFF
--- a/packages/astro-sst/src/adapter.ts
+++ b/packages/astro-sst/src/adapter.ts
@@ -20,29 +20,38 @@ function getAdapter({
 }): AstroAdapter {
   const isStatic = deploymentStrategy === "static";
 
-  const baseConfig: AstroAdapter = {
+  const baseConfig: Pick<AstroAdapter, "name" | "supportedAstroFeatures"> = {
     name: PACKAGE_NAME,
-    serverEntrypoint: `${PACKAGE_NAME}/entrypoint`,
-    args: { responseMode },
-    exports: ["handler"],
-    adapterFeatures: {
-      edgeMiddleware: false,
-      buildOutput: isStatic ? "static" : "server",
-    },
     supportedAstroFeatures: {
       staticOutput: "stable",
       serverOutput: "stable",
-      sharpImageService: "stable",
     },
   };
 
-  return !isStatic
-    ? baseConfig
-    : {
-        name: baseConfig.name,
+  return isStatic
+    ? {
+        ...baseConfig,
+        adapterFeatures: {
+          edgeMiddleware: false,
+          buildOutput: "static",
+        },
         supportedAstroFeatures: {
           ...baseConfig.supportedAstroFeatures,
           sharpImageService: "unsupported",
+        },
+      }
+    : {
+        ...baseConfig,
+        serverEntrypoint: `${PACKAGE_NAME}/entrypoint`,
+        args: { responseMode },
+        exports: ["handler"],
+        adapterFeatures: {
+          edgeMiddleware: false,
+          buildOutput: "server",
+        },
+        supportedAstroFeatures: {
+          ...baseConfig.supportedAstroFeatures,
+          sharpImageService: "stable",
         },
       };
 }


### PR DESCRIPTION
Fixes https://github.com/sst/astro-sst/issues/9

Now static deployments should correctly set the buildOutput to static instead of falling back to the default which is "server". The inverted conditional and dealing with it in the base config felt wrong so just moved the conditional logic to one place but happy for alternate refactorings