### PR TITLE
fix: setting multiple cookies in streaming mode makes an invalid `set-cookie` header.

### DIFF
--- a/.changeset/unlucky-cameras-compete.md
+++ b/.changeset/unlucky-cameras-compete.md
@@ -1,5 +1,0 @@
----
-"astro-sst": patch
----
-
-chore: update astro deprecation

--- a/.changeset/wet-bobcats-cover.md
+++ b/.changeset/wet-bobcats-cover.md
@@ -1,5 +1,0 @@
----
-"astro-sst": patch
----
-
-feat: allow hybrid output

--- a/packages/astro-sst/CHANGELOG.md
+++ b/packages/astro-sst/CHANGELOG.md
@@ -1,5 +1,12 @@
 # astro-sst
 
+## 3.1.4
+
+### Patch Changes
+
+- a934623: chore: update astro deprecation
+- bf4694f: feat: allow hybrid output
+
 ## 3.1.3
 
 ### Patch Changes

--- a/packages/astro-sst/package.json
+++ b/packages/astro-sst/package.json
@@ -1,7 +1,7 @@
 {
   "name": "astro-sst",
   "description": "Adapter that allows Astro to deploy your site to AWS utilizing SST.",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "type": "module",
   "license": "MIT",
   "author": {

--- a/packages/astro-sst/src/lib/event-mapper.ts
+++ b/packages/astro-sst/src/lib/event-mapper.ts
@@ -252,10 +252,9 @@ function convertToApigV2StreamingResult({
   const metadata = {
     statusCode,
     headers,
+    cookies: cookies.length > 0 ? stringifyCookies(cookies) : undefined,
   };
-  if (cookies.length > 0) {
-    metadata.headers["set-cookie"] = stringifyCookies(cookies).join(", ");
-  }
+
   responseStream = awslambda.HttpResponseStream.from(responseStream, metadata);
 
   if (!body) {


### PR DESCRIPTION
For example, when using Astro Auth multiple headers can be set causing them to be concatenated with a comma. This is not a valid `Set-Cookie` header so only the first cookie is honored and the others are discarded.

This causes an issue where certain auth cookies are not set eventually causing errors preventing users from logging in.